### PR TITLE
Fix sync workflow

### DIFF
--- a/.github/workflows/sync-version-with-upstream.yml
+++ b/.github/workflows/sync-version-with-upstream.yml
@@ -1,4 +1,4 @@
-name: Syncs the version the upstream
+name: Update
 
 on:
   schedule:

--- a/.github/workflows/sync-version-with-upstream.yml
+++ b/.github/workflows/sync-version-with-upstream.yml
@@ -23,7 +23,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           update-script: |
             VERSION=$(
-              curl -sL https://api.github.com/repos/google/osv-scanner/releases/latest | jq -r .tag_name
+              curl -sL https://api.github.com/repos/google/osv-scanner/releases/latest | 
+              jq -r '.tag_name' | grep -m1 -vE 'alpha|beta|rc' | tr -d 'v'
             )
             sed -i 's/^\(version: \).*$/\1'"$VERSION"'/' snap/snapcraft.yaml
 

--- a/.github/workflows/sync-version-with-upstream.yml
+++ b/.github/workflows/sync-version-with-upstream.yml
@@ -26,5 +26,5 @@ jobs:
               curl -sL https://api.github.com/repos/google/osv-scanner/releases/latest | 
               jq -r '.tag_name' | grep -m1 -vE 'alpha|beta|rc' | tr -d 'v'
             )
-            sed -i 's/^\(version: \).*$/\1'"$VERSION"'/' snap/snapcraft.yaml
+            sed -i 's/^\(version: \).*$/\1'"$VERSION"'/' snapcraft.yaml
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -2,7 +2,7 @@
 name: osv-scanner
 
 # Version
-version: '1.9.0'
+version: 2.0.2
 
 # Base snap
 base: core22


### PR DESCRIPTION
The workflow to sync the version with upstream is currently broken because it is expecting a `candidate` branch in the repository.

This PR fixes the version extraction and rename the workflow. However, to properly fix the main issue, I suggest renaming the default branch from `main` to `candidate`.
You can see a successful run of the workflow on my fork here https://github.com/upils/osv-scanner-snap/actions/runs/15155943756/job/42610793137

Also, to automatically release a snap in the candidate channel you can use https://github.com/snapcrafters/ci/blob/main/release-to-candidate/README.md . See some usages:
- https://github.com/snapcrafters/terraform/blob/candidate/.github/workflows/release-to-candidate.yaml
- https://github.com/snapcrafters/ruff/blob/candidate/.github/workflows/release-to-candidate.yaml