### PR TITLE
add dpkg & apk paths to snap

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -56,6 +56,20 @@ apps:
     plugs:
       - home
       - network
+      - var-lib-dpkg-status
+      - lib-apk-db-installed
+
+# Plugs, further access to the host from the snap
+plugs:
+  # Artifact system paths supported by the scanner
+  var-lib-dpkg-status:
+    interface: system-files
+    read:
+      - /var/lib/snapd/hostfs/var/lib/dpkg/status
+  lib-apk-db-installed:
+    interface: system-files
+    read:
+      - /var/lib/snapd/hostfs/lib/apk/db/installed
 
 # Name displayed in the software center GUI
 title: OSV-Scanner


### PR DESCRIPTION
allow the snap to access the apk and dpkg host files. 

e.g 
`osv-scanner scan --lockfile 'dpkg-status:/var/lib/snapd/hostfs/var/lib/dpkg/status'`

